### PR TITLE
Add hybrid trust evaluator and blockchain writer integration

### DIFF
--- a/chain/contracts/TrustGraph.sol
+++ b/chain/contracts/TrustGraph.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract TrustGraph {
+    event TrustResultRecorded(bytes32 indexed evaluator, bytes32 indexed entity, bool decision);
+
+    mapping(bytes32 => bool) private trustDecisions;
+
+    function _key(bytes32 evaluator, bytes32 entity) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(evaluator, entity));
+    }
+
+    function setTrustDecision(bytes32 evaluator, bytes32 entity, bool trusted) external {
+        bytes32 key = _key(evaluator, entity);
+        trustDecisions[key] = trusted;
+        emit TrustResultRecorded(evaluator, entity, trusted);
+    }
+
+    function batchSetTrustDecisions(
+        bytes32[] calldata evaluators,
+        bytes32[] calldata entities,
+        bool[] calldata decisions
+    ) external {
+        require(
+            evaluators.length == entities.length &&
+                entities.length == decisions.length,
+            "Length mismatch"
+        );
+        for (uint256 i = 0; i < evaluators.length; i++) {
+            bytes32 key = _key(evaluators[i], entities[i]);
+            trustDecisions[key] = decisions[i];
+            emit TrustResultRecorded(evaluators[i], entities[i], decisions[i]);
+        }
+    }
+
+    function getTrustDecision(bytes32 evaluator, bytes32 entity) external view returns (bool) {
+        return trustDecisions[_key(evaluator, entity)];
+    }
+}

--- a/policies/novartis.json
+++ b/policies/novartis.json
@@ -1,5 +1,11 @@
 {
   "actor": "http://example.org/trust#Novartis",
+  "prob_threshold": 0.7,
+  "_weights": {
+    "hasDeliveryPunctuality": 0.5,
+    "hasPrescriptionComplianceRate": 0.3,
+    "hasGMP": 0.2
+  },
   "trusts": {
     "Transporter": {
       "hasDeliveryPunctuality": { "gte": 0.85 }

--- a/policies/pfizer.json
+++ b/policies/pfizer.json
@@ -1,5 +1,12 @@
 {
   "actor": "http://example.org/trust#Pfizer",
+  "prob_threshold": 0.75,
+  "_weights": {
+    "hasDeliveryPunctuality": 0.7,
+    "hasTempViolationRate": 0.3,
+    "hasAuditScore": 0.6,
+    "hasLicense": 0.4
+  },
   "trusts": {
     "Transporter": {
       "hasDeliveryPunctuality": { "gte": 0.99 },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+rdflib
+pandas
+python-dotenv
+web3

--- a/src/run_hybrid_eval.py
+++ b/src/run_hybrid_eval.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+from trust_evaluator_ext import TrustEvaluatorExt
+
+
+def load_policies(folder: str):
+    arr = []
+    for p in Path(folder).glob("*.json"):
+        arr.append(json.loads(p.read_text(encoding="utf-8")))
+    return arr
+
+
+if __name__ == "__main__":
+    owl = "ontologies/pharma-trust.owl"
+    policies = load_policies("policies")
+
+    eva = TrustEvaluatorExt(owl_path=owl, stats_path="state/trust_stats.json",
+                            gamma=0.25, obs_scale=9.0)
+
+    df0 = eva.run_full_evaluation(policies, export_csv="results/trust_eval_hybrid_round0.csv")
+    print(df0)
+
+    # primer online posodobitve (po potrebi prilagodi)
+    pfizer = "http://example.org/trust#Pfizer"
+    dhl = "http://example.org/trust#DHL"
+    eva.update_from_observation(
+        policy=[p for p in policies if p["actor"] == pfizer][0],
+        actor_type="Transporter",
+        evaluator_uri=pfizer,
+        target_uri=dhl,
+        observed={"hasDeliveryPunctuality": 0.96, "hasTempViolationRate": 0.02}
+    )
+
+    df1 = eva.run_full_evaluation(policies, export_csv="results/trust_eval_hybrid_round1.csv")
+    print(df1)

--- a/src/trust_evaluator_ext.py
+++ b/src/trust_evaluator_ext.py
@@ -1,0 +1,217 @@
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+import pandas as pd
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import RDF
+
+TRUST = Namespace("http://example.org/trust#")
+
+
+def _as_float(value: Literal) -> Optional[float]:
+    try:
+        return float(value.toPython())
+    except Exception:
+        return None
+
+
+def _is_boolean_property(prop: str) -> bool:
+    return prop in {"hasLicense", "hasGMP"}
+
+
+def _desirability(rule: Dict, prop: str, x: Optional[float]) -> Optional[float]:
+    if x is None:
+        return None
+    cond = rule.get(prop)
+    if isinstance(cond, dict):
+        if "gte" in cond:
+            t = float(cond["gte"])
+            if t >= 1.0:
+                return 1.0 if x >= t else 0.0
+            return max(0.0, min(1.0, (x - t) / max(1e-9, (1.0 - t))))
+        if "lte" in cond:
+            t = float(cond["lte"])
+            if t <= 0.0:
+                return 1.0 if x <= t else 0.0
+            return max(0.0, min(1.0, (t - x) / max(1e-9, t)))
+    elif isinstance(cond, bool):
+        return 1.0 if (bool(x) == cond) else 0.0
+    return None
+
+
+class TrustStatsStore:
+    """
+    Shranjuje posteriorje Beta(α, β) za (evaluator, entity, property).
+    EWMA posodobitev:
+      alpha <- (1-γ)*alpha + γ*(1 + s*obs_scale)
+      beta  <- (1-γ)*beta  + γ*(1 + (1-s)*obs_scale)
+    """
+    def __init__(self, path: str, gamma: float = 0.2, obs_scale: float = 9.0):
+        self.path = Path(path)
+        self.gamma = float(gamma)
+        self.obs_scale = float(obs_scale)
+        self._store = {}
+        if self.path.exists():
+            try:
+                self._store = json.loads(self.path.read_text(encoding="utf-8"))
+            except Exception:
+                self._store = {}
+
+    def _key(self, evaluator_uri: str, entity_uri: str, prop: str) -> str:
+        return f"{evaluator_uri}||{entity_uri}||{prop}"
+
+    def get(self, evaluator_uri: str, entity_uri: str, prop: str) -> Tuple[float, float]:
+        rec = self._store.get(self._key(evaluator_uri, entity_uri, prop))
+        if not rec:
+            return (1.0, 1.0)
+        return float(rec["alpha"]), float(rec["beta"])
+
+    def seed(self, evaluator_uri: str, entity_uri: str, prop: str, s0: float):
+        k = self._key(evaluator_uri, entity_uri, prop)
+        if k in self._store:
+            return
+        alpha0 = 1.0 + s0 * self.obs_scale
+        beta0 = 1.0 + (1.0 - s0) * self.obs_scale
+        self._store[k] = {"alpha": alpha0, "beta": beta0}
+
+    def update(self, evaluator_uri: str, entity_uri: str, prop: str, s: float):
+        alpha, beta = self.get(evaluator_uri, entity_uri, prop)
+        g = self.gamma
+        a_new = (1 - g) * alpha + g * (1.0 + s * self.obs_scale)
+        b_new = (1 - g) * beta + g * (1.0 + (1.0 - s) * self.obs_scale)
+        self._store[self._key(evaluator_uri, entity_uri, prop)] = {"alpha": a_new, "beta": b_new}
+
+    def save(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._store, indent=2), encoding="utf-8")
+
+
+class TrustEvaluatorExt:
+    """
+    Hibridni evaluator:
+      - deterministična presoja JSON pravil,
+      - verjetnostni score z Beta-EWMA,
+      - kombinirana odločitev (OR; možno spremeniti).
+    """
+    def __init__(self, owl_path: str, stats_path: str = "state/trust_stats.json",
+                 gamma: float = 0.2, obs_scale: float = 9.0):
+        self.g = Graph()
+        self.g.parse(owl_path, format="application/rdf+xml")
+        self.stats = TrustStatsStore(stats_path, gamma=gamma, obs_scale=obs_scale)
+
+    # ------ ontology utilities ------
+    def get_all_entity_uris(self) -> List[str]:
+        subjects = set()
+        for s, p, o in self.g:
+            if str(p).startswith(str(TRUST)) and isinstance(o, Literal):
+                subjects.add(str(s))
+        return list(subjects)
+
+    def get_type_for_entity(self, entity_uri: str) -> Optional[str]:
+        for _, _, o in self.g.triples((URIRef(entity_uri), RDF.type, None)):
+            if str(o).startswith(str(TRUST)):
+                return str(o).split("#")[-1]
+        return None
+
+    def get_value(self, entity_uri: str, prop: str) -> Optional[float]:
+        val = self.g.value(subject=URIRef(entity_uri), predicate=TRUST[prop])
+        if val is None:
+            return None
+        if _is_boolean_property(prop):
+            return 1.0 if bool(val.toPython()) else 0.0
+        return _as_float(val)
+
+    # ------ deterministic ------
+    def eval_deterministic(self, policy: Dict, actor_type: str, target_uri: str) -> bool:
+        conditions = policy.get("trusts", {}).get(actor_type, {})
+        for prop, cond in conditions.items():
+            x = self.get_value(target_uri, prop)
+            if x is None:
+                return False
+            if isinstance(cond, dict):
+                for op, t in cond.items():
+                    t = float(t)
+                    if op == "gte" and x < t:
+                        return False
+                    if op == "lte" and x > t:
+                        return False
+            elif isinstance(cond, bool):
+                if bool(x) != cond:
+                    return False
+        return True
+
+    # ------ probabilistic ------
+    def _weights_for(self, policy: Dict, actor_type: str) -> Dict[str, float]:
+        conds = policy.get("trusts", {}).get(actor_type, {})
+        ws = policy.get("_weights", {})
+        active = {p: float(ws.get(p, 1.0)) for p in conds.keys()}
+        s = sum(active.values()) or 1.0
+        return {k: v / s for k, v in active.items()}
+
+    def _seed_from_ontology(self, evaluator_uri: str, target_uri: str, conds: Dict):
+        for prop in conds.keys():
+            x = self.get_value(target_uri, prop)
+            s0 = _desirability(conds, prop, x)
+            if s0 is not None:
+                self.stats.seed(evaluator_uri, target_uri, prop, s0)
+
+    def eval_probabilistic(self, policy: Dict, actor_type: str, target_uri: str):
+        evaluator_uri = policy["actor"]
+        conds = policy.get("trusts", {}).get(actor_type, {})
+        if not conds:
+            return (0.0, False)
+        self._seed_from_ontology(evaluator_uri, target_uri, conds)
+        ws = self._weights_for(policy, actor_type)
+        parts = []
+        for prop in conds.keys():
+            alpha, beta = self.stats.get(evaluator_uri, target_uri, prop)
+            mean = alpha / (alpha + beta)
+            parts.append(ws[prop] * mean)
+        score = sum(parts) if parts else 0.0
+        thr = float(policy.get("prob_threshold", 0.7))
+        return (score, score >= thr)
+
+    # ------ online updates ------
+    def update_from_observation(self, policy: Dict, actor_type: str,
+                                evaluator_uri: str, target_uri: str,
+                                observed: Dict[str, float]):
+        conds = policy.get("trusts", {}).get(actor_type, {})
+        for prop in conds.keys():
+            if prop not in observed:
+                continue
+            s = _desirability(conds, prop, float(observed[prop]))
+            if s is not None:
+                self.stats.update(evaluator_uri, target_uri, prop, s)
+        self.stats.save()
+
+    # ------ run & export ------
+    def run_full_evaluation(self, policies: List[Dict], export_csv: str = "results/trust_eval_hybrid.csv") -> pd.DataFrame:
+        targets = self.get_all_entity_uris()
+        rows = []
+        for policy in policies:
+            evaluator_uri = policy["actor"]
+            evaluator = evaluator_uri.split("#")[-1]
+            for target_uri in targets:
+                entity = target_uri.split("#")[-1]
+                if evaluator_uri.endswith(f"#{entity}"):
+                    continue
+                ttype = self.get_type_for_entity(target_uri)
+                if not ttype or ttype not in policy.get("trusts", {}):
+                    continue
+                det_dec = self.eval_deterministic(policy, ttype, target_uri)
+                prob_score, prob_dec = self.eval_probabilistic(policy, ttype, target_uri)
+                combined = det_dec or prob_dec
+                rows.append({
+                    "Evaluator": evaluator,
+                    "Entity": entity,
+                    "Type": ttype,
+                    "Deterministic": det_dec,
+                    "ProbScore": round(prob_score, 4),
+                    "ProbDecision": prob_dec,
+                    "CombinedDecision": combined
+                })
+        df = pd.DataFrame(rows)
+        Path(export_csv).parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(export_csv, index=False)
+        return df

--- a/src/write_results_onchain.py
+++ b/src/write_results_onchain.py
@@ -1,0 +1,134 @@
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+from dotenv import load_dotenv
+from web3 import Web3
+from web3.contract import Contract
+
+TRUST_GRAPH_ABI = [
+    {
+        "inputs": [
+            {"internalType": "bytes32", "name": "evaluator", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "entity", "type": "bytes32"},
+            {"internalType": "bool", "name": "trusted", "type": "bool"},
+        ],
+        "name": "setTrustDecision",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "bytes32[]", "name": "evaluators", "type": "bytes32[]"},
+            {"internalType": "bytes32[]", "name": "entities", "type": "bytes32[]"},
+            {"internalType": "bool[]", "name": "decisions", "type": "bool[]"},
+        ],
+        "name": "batchSetTrustDecisions",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+
+def _load_env() -> dict:
+    load_dotenv()
+    cfg = {
+        "rpc_url": os.getenv("RPC_URL"),
+        "contract_address": os.getenv("CONTRACT_ADDRESS"),
+        "private_key": os.getenv("PRIVATE_KEY"),
+        "namespace": os.getenv("NAMESPACE", "http://example.org/trust#"),
+        "csv_path": os.getenv("TRUST_RESULTS_CSV", "results/trust_eval_hybrid_round1.csv"),
+    }
+    missing = [k for k, v in cfg.items() if v in (None, "") and k != "namespace"]
+    if missing:
+        raise EnvironmentError(f"Missing required environment variables: {', '.join(missing)}")
+    return cfg
+
+
+def _normalise_namespace(namespace: str) -> str:
+    namespace = namespace or ""
+    if not namespace:
+        return ""
+    return namespace.rstrip("#/")
+
+
+def _to_uri(label: str, namespace: str) -> str:
+    if label.startswith("http://") or label.startswith("https://"):
+        return label
+    base = _normalise_namespace(namespace)
+    if not base:
+        return label
+    return f"{base}#{label}"
+
+
+def _hash_identifiers(values: Iterable[str], namespace: str) -> List[bytes]:
+    w3 = Web3()
+    hashed = []
+    for val in values:
+        uri = _to_uri(str(val), namespace)
+        hashed.append(bytes(w3.keccak(text=uri)))
+    return hashed
+
+
+def _load_contract(w3: Web3, address: str) -> Contract:
+    checksum = w3.to_checksum_address(address)
+    return w3.eth.contract(address=checksum, abi=TRUST_GRAPH_ABI)
+
+
+def _to_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(int(value))
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "t"}
+    return bool(value)
+
+
+def main():
+    cfg = _load_env()
+    csv_path = Path(cfg["csv_path"])
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+    required_cols = {"Evaluator", "Entity", "CombinedDecision"}
+    if not required_cols.issubset(df.columns):
+        raise ValueError(f"CSV must contain columns: {sorted(required_cols)}")
+
+    w3 = Web3(Web3.HTTPProvider(cfg["rpc_url"]))
+    if not w3.is_connected():
+        raise ConnectionError("Failed to connect to RPC endpoint")
+
+    account = w3.eth.account.from_key(cfg["private_key"])
+    contract = _load_contract(w3, cfg["contract_address"])
+
+    evaluators = _hash_identifiers(df["Evaluator"], cfg["namespace"])
+    entities = _hash_identifiers(df["Entity"], cfg["namespace"])
+    decisions = [_to_bool(val) for val in df["CombinedDecision"]]
+
+    tx = contract.functions.batchSetTrustDecisions(
+        evaluators,
+        entities,
+        decisions,
+    ).build_transaction(
+        {
+            "from": account.address,
+            "nonce": w3.eth.get_transaction_count(account.address),
+            "gasPrice": w3.eth.gas_price,
+        }
+    )
+
+    signed = account.sign_transaction(tx)
+    tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+
+    print("Submitted trust results to blockchain")
+    print(f"Tx hash: {receipt.transactionHash.hex()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a hybrid trust evaluator that blends deterministic rules with a Beta-EWMA trust score and exports combined decisions
- add a driver script, supporting requirements, and enrich existing policies for probabilistic weighting and thresholds
- create a TrustGraph smart contract plus an on-chain writer that hashes evaluator/entity identifiers and submits combined decisions

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e652d356c88326891a0d8d862d88bf